### PR TITLE
chore: reinstate requested resources in OpenShift

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -44,37 +44,37 @@ jobs:
       environment: test
       db_user: app
 
-  # deploy-prod:
-  #   name: Deploy (prod)
-  #   needs: [deploy-test, vars]
-  #   uses: ./.github/workflows/.deployer.yml
-  #   secrets:
-  #     oc_namespace: ${{ secrets.OC_NAMESPACE }}
-  #     oc_token: ${{ secrets.OC_TOKEN }}
-  #   with:
-  #     environment: prod
-  #     db_user: app
-  #     params:
-  #       --set backend.deploymentStrategy=RollingUpdate
-  #       --set frontend.deploymentStrategy=RollingUpdate
-  #       --set global.autoscaling=true
-  #       --set frontend.pdb.enabled=true
-  #       --set backend.pdb.enabled=true
+  deploy-prod:
+    name: Deploy (prod)
+    needs: [deploy-test, vars]
+    uses: ./.github/workflows/.deployer.yml
+    secrets:
+      oc_namespace: ${{ secrets.OC_NAMESPACE }}
+      oc_token: ${{ secrets.OC_TOKEN }}
+    with:
+      environment: prod
+      db_user: app
+      params:
+        --set backend.deploymentStrategy=RollingUpdate
+        --set frontend.deploymentStrategy=RollingUpdate
+        --set global.autoscaling=true
+        --set frontend.pdb.enabled=true
+        --set backend.pdb.enabled=true
 
-  # promote:
-  #   name: Promote Images
-  #   needs: [deploy-prod, vars]
-  #   runs-on: ubuntu-24.04
-  #   permissions:
-  #     packages: write
-  #   strategy:
-  #     matrix:
-  #       package: [migrations, backend, frontend]
-  #   timeout-minutes: 1
-  #   steps:
-  #     - uses: shrink/actions-docker-registry-tag@v4
-  #       with:
-  #         registry: ghcr.io
-  #         repository: ${{ github.repository }}/${{ matrix.package }}
-  #         target: ${{ needs.vars.outputs.pr }}
-  #         tags: prod
+  promote:
+    name: Promote Images
+    needs: [deploy-prod, vars]
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        package: [migrations, backend, frontend]
+    timeout-minutes: 1
+    steps:
+      - uses: shrink/actions-docker-registry-tag@v4
+        with:
+          registry: ghcr.io
+          repository: ${{ github.repository }}/${{ matrix.package }}
+          target: ${{ needs.vars.outputs.pr }}
+          tags: prod

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -35,9 +35,9 @@ backend:
     #-- enable or disable autoscaling.
     enabled: true
     #-- the minimum number of replicas.
-    minReplicas: 1
+    minReplicas: 3
     #-- the maximum number of replicas.
-    maxReplicas: 3
+    maxReplicas: 7
     #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
     targetCPUUtilizationPercentage: 80
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
@@ -83,9 +83,9 @@ frontend:
     #-- enable or disable autoscaling.
     enabled: true
     #-- the minimum number of replicas.
-    minReplicas: 1
+    minReplicas: 3
     #-- the maximum number of replicas.
-    maxReplicas: 3
+    maxReplicas: 7
     #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
     targetCPUUtilizationPercentage: 80
   #-- the service for the component. for inter namespace communication, use the service name as the hostname.


### PR DESCRIPTION
Restores the original Helm charts and GitHub workflows, as the resource limit has been resolved elsewhere.

This reverts commit 37822313ca282f04c6a9fc3227a5a8420c0cf48e.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://tei-4-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://tei-4-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tei/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tei/actions/workflows/merge.yml)