### PR TITLE
fix: update merge workflow handling of PR number inputs

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,14 +24,24 @@ jobs:
   vars:
     name: Set Variables
     outputs:
-      pr: ${{ steps.pr.outputs.pr }}
+      pr: ${{ steps.pr-selector.outputs.pr }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
-      # Get PR number for squash merges to main
+      # Get PR number for squash merges to main if not specified as input
       - name: PR Number
         id: pr
+        if: github.event.inputs.pr_no == null
         uses: bcgov-nr/action-get-pr@v0.0.1
+      # Get the appropriate PR number output value depending on whether input was specified
+      - name: PR Number Selector
+        id: pr-selector
+        run: |
+          if [[ "${{ github.event.inputs.pr_no }}" == "" ]]; then
+              echo "pr=${{ steps.pr.outputs.pr }}" >> $GITHUB_OUTPUT
+          else
+              echo "pr=${{ github.event.inputs.pr_no }}" >> $GITHUB_OUTPUT
+          fi
 
   # https://github.com/bcgov/quickstart-openshift-helpers
   deploy-test:


### PR DESCRIPTION
Fixes the merge workflow trying to retrieve the PR number from the latest commit even if the workflow was launched manually with a PR number provided as input.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://tei-5-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://tei-5-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tei/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tei/actions/workflows/merge.yml)