### PR TITLE
fix: update merge workflow handling of PR number inputs, part 2

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -53,6 +53,7 @@ jobs:
     with:
       environment: test
       db_user: app
+      tag: ${{ needs.vars.outputs.pr }}
 
   deploy-prod:
     name: Deploy (prod)
@@ -64,6 +65,7 @@ jobs:
     with:
       environment: prod
       db_user: app
+      tag: ${{ needs.vars.outputs.pr }}
       params:
         --set backend.deploymentStrategy=RollingUpdate
         --set frontend.deploymentStrategy=RollingUpdate


### PR DESCRIPTION
Fixes the merge workflow trying to retrieve the PR number from the latest commit even if the workflow was launched manually with a PR number provided as input.  This addresses a piece that was missing from the original fix.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://tei-6-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://tei-6-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tei/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tei/actions/workflows/merge.yml)