### PR TITLE
fix: update merge workflow handling of PR number inputs, part 3

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -46,6 +46,7 @@ jobs:
   # https://github.com/bcgov/quickstart-openshift-helpers
   deploy-test:
     name: Deploy (test)
+    needs: [vars]
     uses: ./.github/workflows/.deployer.yml
     secrets:
       oc_namespace: ${{ secrets.OC_NAMESPACE }}


### PR DESCRIPTION
Fixes the merge workflow trying to retrieve the PR number from the latest commit even if the workflow was launched manually with a PR number provided as input. This addresses a piece that was missing from the first 2 fixes.

---

Thanks for the PR!

Deployments, as required, will be available below:
- [Frontend](https://tei-7-frontend.apps.silver.devops.gov.bc.ca)
- [Backend](https://tei-7-frontend.apps.silver.devops.gov.bc.ca/api)


Please create PRs in draft mode.  Mark as ready to enable:
- [Analysis Workflow](https://github.com/bcgov/tei/actions/workflows/analysis.yml)

After merge, new images are deployed in:
- [Merge Workflow](https://github.com/bcgov/tei/actions/workflows/merge.yml)